### PR TITLE
Load root certs if system cert pool is empty

### DIFF
--- a/rootcerts.go
+++ b/rootcerts.go
@@ -37,7 +37,7 @@ func init() {
 	// Ensure x509.SystemCertPool is executed once
 	x509.SystemCertPool() // nolint: errcheck
 
-	if systemRoots != nil && os.Getenv(forceEnableEnvVar) != "1" {
+	if systemRoots != nil && len(systemRoots.Subjects()) > 0 && os.Getenv(forceEnableEnvVar) != "1" {
 		return
 	}
 


### PR DESCRIPTION
If loading of the system cert pool does not return an error,
but no certificates have been found, the system cert pool
is non nil but empty (len == 0).
In this case, the embedded root certs should be used as well.